### PR TITLE
ANIDB 648: Change tvdb_id from 85230 to 77773

### DIFF
--- a/anime_ids.json
+++ b/anime_ids.json
@@ -4200,7 +4200,7 @@
     "tvdb_epoffset": 0
   },
   "648": {
-    "tvdb_id": 85230,
+    "tvdb_id": 77773,
     "tvdb_season": 1,
     "tvdb_epoffset": 0,
     "mal_id": 1650,


### PR DESCRIPTION
Update tvdb for Star Blazers to the correct id. previous id (85230) was erroneous.

https://www.thetvdb.com/series/star-blazers#general

https://anidb.net/anime/648
